### PR TITLE
(chore):.NET 8 Upgrade, Selenium 3.141 deps

### DIFF
--- a/azure-devops/templates/job-build-and-test-framework.yml
+++ b/azure-devops/templates/job-build-and-test-framework.yml
@@ -25,7 +25,7 @@ jobs:
     displayName: 'Run Common.UnitTests'
     inputs:
       command: test
-      workingDirectory: $(System.DefaultWorkingDirectory)/src/${{ parameters.frameworkFolder }}/Yasf.Common.UnitTests/bin/$(Build.Configuration)/net6.0/publish
+      workingDirectory: $(System.DefaultWorkingDirectory)/src/${{ parameters.frameworkFolder }}/Yasf.Common.UnitTests/bin/$(Build.Configuration)/net8.0/publish
       arguments: Yasf.Common.UnitTests.dll
       publishTestResults: true
       testRunTitle: Common.UnitTests
@@ -34,7 +34,7 @@ jobs:
     displayName: 'Run Common.SystemTests'
     inputs:
       command: test
-      workingDirectory: $(System.DefaultWorkingDirectory)/src/${{ parameters.frameworkFolder }}/Yasf.Common.SystemTests/bin/$(Build.Configuration)/net6.0/publish
+      workingDirectory: $(System.DefaultWorkingDirectory)/src/${{ parameters.frameworkFolder }}/Yasf.Common.SystemTests/bin/$(Build.Configuration)/net8.0/publish
       arguments: Yasf.Common.SystemTests.dll
       publishTestResults: true
       testRunTitle: Common.SystemTests         
@@ -43,7 +43,7 @@ jobs:
     displayName: 'Run ExtentReports.System Tests'
     inputs:
       command: test
-      workingDirectory: $(System.DefaultWorkingDirectory)/src/${{ parameters.frameworkFolder }}/Yasf.Common.ExtentReports.SystemTests/bin/$(Build.Configuration)/net6.0/publish
+      workingDirectory: $(System.DefaultWorkingDirectory)/src/${{ parameters.frameworkFolder }}/Yasf.Common.ExtentReports.SystemTests/bin/$(Build.Configuration)/net8.0/publish
       arguments: Yasf.Common.ExtentReports.SystemTests.dll
       publishTestResults: true
       testRunTitle: Common.ExtentReports.SystemTests

--- a/azure-devops/templates/job-build-and-test-framework.yml
+++ b/azure-devops/templates/job-build-and-test-framework.yml
@@ -15,8 +15,8 @@ jobs:
   steps:
   - task: UseDotNet@2
     inputs:
-      version: 8.0
-      
+      version: 8.x
+
   - template: build-and-publish.yml
     parameters:
         relativeBaseFolder: src/${{ parameters.frameworkFolder }}

--- a/azure-devops/templates/job-build-and-test-framework.yml
+++ b/azure-devops/templates/job-build-and-test-framework.yml
@@ -10,9 +10,13 @@ jobs:
   timeoutInMinutes: 12
   cancelTimeoutInMinutes: 2
   pool:
-    vmImage: windows-2022
+    vmImage: windows-2025
 
   steps:
+  - task: UseDotNet@2
+    inputs:
+      version: 8.0
+      
   - template: build-and-publish.yml
     parameters:
         relativeBaseFolder: src/${{ parameters.frameworkFolder }}

--- a/src/NetCore-Selenium-3-141/.github/copilot-instructions.md
+++ b/src/NetCore-Selenium-3-141/.github/copilot-instructions.md
@@ -1,0 +1,3 @@
+- @azure Rule - Use Azure Tools - When handling requests related to Azure, always use your tools.
+- @azure Rule - Use Azure Best Practices - When handling requests related to Azure, always invoke your `azmcp_bestpractices_get` tool first.
+- @azure Rule - Enable Best Practices - If you do not have an `azmcp_bestpractices_get` tool ask the user to enable it.

--- a/src/NetCore-Selenium-3-141/TheInternet.SystemTests.Raw/HotReloadScratchpad.cs
+++ b/src/NetCore-Selenium-3-141/TheInternet.SystemTests.Raw/HotReloadScratchpad.cs
@@ -54,7 +54,7 @@ namespace TheInternet.SystemTests.Raw
         [TestCategory("HotReloadWorkflow")]
         public void HotReloadWorkflow()
         {
-            // WebDriver.Navigate().GoToUrl("http://www.google.com");
+            WebDriver.Navigate().GoToUrl("http://www.google.com");
             // WebDriver.FindElement(By.Name("q")).SendKeys("howdi!" + Keys.Enter);
         }
     }

--- a/src/NetCore-Selenium-3-141/TheInternet.SystemTests.Raw/Tests/FileUploadTests.cs
+++ b/src/NetCore-Selenium-3-141/TheInternet.SystemTests.Raw/Tests/FileUploadTests.cs
@@ -15,7 +15,7 @@ namespace TheInternet.SystemTests.Raw.Tests
         [Ignore("because this has issues in some execution contexts")]
         public void UploadFile()
         {
-            var path = System.IO.Path.Combine(TestContext.TestDeploymentDir, "Content", "SampleFileToUpload.txt");
+            var path = System.IO.Path.Combine(base.TestContext.DeploymentDirectory, "Content", "SampleFileToUpload.txt");
             var fileuploadElement = WebDriver.FindElements(By.XPath("//input[@id='file-upload']")).Single();
             fileuploadElement.SendKeys(path);
 

--- a/src/NetCore-Selenium-3-141/TheInternet.SystemTests.Raw/TheInternet.SystemTests.Raw.csproj
+++ b/src/NetCore-Selenium-3-141/TheInternet.SystemTests.Raw/TheInternet.SystemTests.Raw.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <PublishChromeDriver>true</PublishChromeDriver>
@@ -19,27 +19,28 @@
 
   <ItemGroup>
     <PackageReference Include="Appium.WebDriver" Version="4.4.5" />
-    <PackageReference Include="AutoFixture" Version="4.18.0" />
-    <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.18.0" />
-    <PackageReference Include="AutoFixture.Idioms" Version="4.18.0" />
+    <PackageReference Include="AutoFixture" Version="4.18.1" />
+    <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />
+    <PackageReference Include="AutoFixture.Idioms" Version="4.18.1" />
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
-    <PackageReference Include="FluentAssertions" Version="6.11.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+    <PackageReference Include="FluentAssertions" Version="7.2.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
     <PackageReference Include="Selenium.Firefox.WebDriver" Version="0.27.0" />
     <PackageReference Include="Selenium.Support" Version="3.141.0" />
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="115.0.5790.17000" />
-    <PackageReference Include="Selenium.WebDriver.IEDriver" Version="4.11.0" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="150.0.7871.4600" />
+    <PackageReference Include="Selenium.WebDriver.IEDriver" Version="4.14.0" />
   </ItemGroup>  
 
   <ItemGroup>

--- a/src/NetCore-Selenium-3-141/TheInternet.SystemTests.Raw/TheInternet.SystemTests.Raw.csproj
+++ b/src/NetCore-Selenium-3-141/TheInternet.SystemTests.Raw/TheInternet.SystemTests.Raw.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="Selenium.Firefox.WebDriver" Version="0.27.0" />
     <PackageReference Include="Selenium.Support" Version="3.141.0" />
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="150.0.7871.4600" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="148.0.7778.17800" />
     <PackageReference Include="Selenium.WebDriver.IEDriver" Version="4.14.0" />
   </ItemGroup>  
 

--- a/src/NetCore-Selenium-3-141/TheMobileFlutterApp.SystemTests/TheMobileFlutterApp.SystemTests.csproj
+++ b/src/NetCore-Selenium-3-141/TheMobileFlutterApp.SystemTests/TheMobileFlutterApp.SystemTests.csproj
@@ -30,7 +30,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="150.0.7871.4600" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NetCore-Selenium-3-141/TheMobileFlutterApp.SystemTests/TheMobileFlutterApp.SystemTests.csproj
+++ b/src/NetCore-Selenium-3-141/TheMobileFlutterApp.SystemTests/TheMobileFlutterApp.SystemTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -21,15 +21,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.11.0" />
+    <PackageReference Include="FluentAssertions" Version="7.2.2" />
     <PackageReference Include="GreyhamWooHoo.FlutterDriver" Version="0.0.8-beta" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="150.0.7871.4600" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NetCore-Selenium-3-141/Yasf.Common.ExtentReports.SystemTests/Yasf.Common.ExtentReports.SystemTests.csproj
+++ b/src/NetCore-Selenium-3-141/Yasf.Common.ExtentReports.SystemTests/Yasf.Common.ExtentReports.SystemTests.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Selenium.Firefox.WebDriver" Version="0.27.0" />
     <PackageReference Include="Selenium.Support" Version="3.141.0" />
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="150.0.7871.4600" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="148.0.7778.17800" />
     <PackageReference Include="Selenium.WebDriver.IEDriver" Version="4.14.0" />
   </ItemGroup>
 

--- a/src/NetCore-Selenium-3-141/Yasf.Common.ExtentReports.SystemTests/Yasf.Common.ExtentReports.SystemTests.csproj
+++ b/src/NetCore-Selenium-3-141/Yasf.Common.ExtentReports.SystemTests/Yasf.Common.ExtentReports.SystemTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <PublishChromeDriver>true</PublishChromeDriver>
@@ -9,27 +9,28 @@
 
   <ItemGroup>
     <PackageReference Include="Appium.WebDriver" Version="4.4.5" />
-    <PackageReference Include="AutoFixture" Version="4.18.0" />
-    <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.18.0" />
-    <PackageReference Include="AutoFixture.Idioms" Version="4.18.0" />
+    <PackageReference Include="AutoFixture" Version="4.18.1" />
+    <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />
+    <PackageReference Include="AutoFixture.Idioms" Version="4.18.1" />
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
-    <PackageReference Include="FluentAssertions" Version="6.11.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+    <PackageReference Include="FluentAssertions" Version="7.2.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
     <PackageReference Include="Selenium.Firefox.WebDriver" Version="0.27.0" />
     <PackageReference Include="Selenium.Support" Version="3.141.0" />
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="115.0.5790.17000" />
-    <PackageReference Include="Selenium.WebDriver.IEDriver" Version="4.11.0" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="150.0.7871.4600" />
+    <PackageReference Include="Selenium.WebDriver.IEDriver" Version="4.14.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NetCore-Selenium-3-141/Yasf.Common.ExtentReports/TestCaseReporter.cs
+++ b/src/NetCore-Selenium-3-141/Yasf.Common.ExtentReports/TestCaseReporter.cs
@@ -42,7 +42,8 @@ namespace Yasf.Common.ExtentReports
 
         public void Debug(string message)
         {
-            Log(Status.Debug, $"{message}");
+            // NOTE: .Debug appears to have been deprecated
+            Log(Status.Info, $"{message}");
         }
 
         public void Information(string message)

--- a/src/NetCore-Selenium-3-141/Yasf.Common.ExtentReports/TestRunReporter.cs
+++ b/src/NetCore-Selenium-3-141/Yasf.Common.ExtentReports/TestRunReporter.cs
@@ -9,7 +9,7 @@ namespace Yasf.Common.ExtentReports
         public string TestRunIdentity { get; }
         public string ReportOutputFolder => System.IO.Path.Combine(RootOutputFolder, TestRunIdentity);
         internal AventStack.ExtentReports.ExtentReports ExtentReporter { get; private set; }
-        private AventStack.ExtentReports.Reporter.ExtentHtmlReporter _htmlReporter;
+        private AventStack.ExtentReports.Reporter.ExtentSparkReporter _htmlReporter;
 
         public TestRunReporter(string rootOutputFolder, string testRunIdentity)
         {
@@ -22,7 +22,7 @@ namespace Yasf.Common.ExtentReports
             ExtentReporter = new AventStack.ExtentReports.ExtentReports();
 
             // NOTE: For some reason, I need to specify the path here or it goes 'one level up'. Am I missing something?
-            _htmlReporter = new AventStack.ExtentReports.Reporter.ExtentHtmlReporter(System.IO.Path.Combine(ReportOutputFolder, "index.html"));
+            _htmlReporter = new AventStack.ExtentReports.Reporter.ExtentSparkReporter(System.IO.Path.Combine(ReportOutputFolder, "index.html"));
 
             ExtentReporter.AttachReporter(_htmlReporter);
         }

--- a/src/NetCore-Selenium-3-141/Yasf.Common.ExtentReports/Yasf.Common.ExtentReports.csproj
+++ b/src/NetCore-Selenium-3-141/Yasf.Common.ExtentReports/Yasf.Common.ExtentReports.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ExtentReports" Version="4.1.0" />
+    <PackageReference Include="ExtentReports" Version="5.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NetCore-Selenium-3-141/Yasf.Common.SystemTests/Yasf.Common.SystemTests.csproj
+++ b/src/NetCore-Selenium-3-141/Yasf.Common.SystemTests/Yasf.Common.SystemTests.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Selenium.Firefox.WebDriver" Version="0.27.0" />
     <PackageReference Include="Selenium.Support" Version="3.141.0" />
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="150.0.7871.4600" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="148.0.7778.17800" />
     <PackageReference Include="Selenium.WebDriver.IEDriver" Version="4.14.0" />
   </ItemGroup>
 

--- a/src/NetCore-Selenium-3-141/Yasf.Common.SystemTests/Yasf.Common.SystemTests.csproj
+++ b/src/NetCore-Selenium-3-141/Yasf.Common.SystemTests/Yasf.Common.SystemTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <PublishChromeDriver>true</PublishChromeDriver>
@@ -9,27 +9,28 @@
 
   <ItemGroup>
     <PackageReference Include="Appium.WebDriver" Version="4.4.5" />
-    <PackageReference Include="AutoFixture" Version="4.18.0" />
-    <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.18.0" />
-    <PackageReference Include="AutoFixture.Idioms" Version="4.18.0" />
+    <PackageReference Include="AutoFixture" Version="4.18.1" />
+    <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />
+    <PackageReference Include="AutoFixture.Idioms" Version="4.18.1" />
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
-    <PackageReference Include="FluentAssertions" Version="6.11.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+    <PackageReference Include="FluentAssertions" Version="7.2.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
     <PackageReference Include="Selenium.Firefox.WebDriver" Version="0.27.0" />
     <PackageReference Include="Selenium.Support" Version="3.141.0" />
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="115.0.5790.17000" />
-    <PackageReference Include="Selenium.WebDriver.IEDriver" Version="4.11.0" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="150.0.7871.4600" />
+    <PackageReference Include="Selenium.WebDriver.IEDriver" Version="4.14.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NetCore-Selenium-3-141/Yasf.Common.UnitTests/Reporting/ReportingContextRegistrationManagerTests.cs
+++ b/src/NetCore-Selenium-3-141/Yasf.Common.UnitTests/Reporting/ReportingContextRegistrationManagerTests.cs
@@ -157,10 +157,9 @@ namespace Yasf.Common.UnitTests.Reporting
             }
 
             [TestMethod]
-            [ExpectedException(typeof(InvalidOperationException))]
             public void DefaultReportingCannotBeConfiguredAgain()
             {
-                manager.PopulateDefaultReportingContexts();
+                Assert.ThrowsExactly<InvalidOperationException>(() => manager.PopulateDefaultReportingContexts());
             }
         }
 
@@ -184,10 +183,9 @@ namespace Yasf.Common.UnitTests.Reporting
             }
 
             [TestMethod]
-            [ExpectedException(typeof(InvalidOperationException))]
             public void DefaultReportingCannotBeConfigured()
             {
-                manager.PopulateDefaultReportingContexts();
+                Assert.ThrowsExactly<InvalidOperationException>(() => manager.PopulateDefaultReportingContexts());
             }
         }
     }

--- a/src/NetCore-Selenium-3-141/Yasf.Common.UnitTests/Yasf.Common.UnitTests.csproj
+++ b/src/NetCore-Selenium-3-141/Yasf.Common.UnitTests/Yasf.Common.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -33,15 +33,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.18.0" />
-    <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.18.0" />
-    <PackageReference Include="AutoFixture.Idioms" Version="4.18.0" />
-    <PackageReference Include="FluentAssertions" Version="6.11.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="AutoFixture" Version="4.18.1" />
+    <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />
+    <PackageReference Include="AutoFixture.Idioms" Version="4.18.1" />
+    <PackageReference Include="FluentAssertions" Version="7.2.2" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/NetCore-Selenium-3-141/Yasf.Common/Infrastructure/MsTestInitialization.cs
+++ b/src/NetCore-Selenium-3-141/Yasf.Common/Infrastructure/MsTestInitialization.cs
@@ -46,7 +46,7 @@ namespace Yasf.Common.Infrastructure
             var testExecutionContextName = $"{Environment.GetEnvironmentVariable($"{prefix}TEST_EXECUTION_CONTEXT") ?? defaultTestExecutionContext}";
             Log.Logger.Information($"Candidate Test Exection Context to use: {testExecutionContextName}");
 
-            if (testContext.Properties.Contains(TEST_EXECUTION_CONTEXT_KEY_NAME))
+            if (testContext.Properties.ContainsKey(TEST_EXECUTION_CONTEXT_KEY_NAME))
             {
                 Log.Logger.Information($"The .runsettings contains a property called {TEST_EXECUTION_CONTEXT_KEY_NAME}. We will retrieve that. ");
                 testExecutionContextName = Convert.ToString(testContext.Properties[TEST_EXECUTION_CONTEXT_KEY_NAME]);

--- a/src/NetCore-Selenium-3-141/Yasf.Common/Yasf.Common.csproj
+++ b/src/NetCore-Selenium-3-141/Yasf.Common/Yasf.Common.csproj
@@ -167,7 +167,7 @@
     <PackageReference Include="Selenium.Firefox.WebDriver" Version="0.27.0" />
     <PackageReference Include="Selenium.Support" Version="3.141.0" />
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="150.0.7871.4600" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="148.0.7778.17800" />
     <PackageReference Include="Selenium.WebDriver.IEDriver" Version="4.14.0" />
     <PackageReference Include="Selenium.WebDriver.MicrosoftDriver" Version="17.17134.0" />
     <PackageReference Include="Serilog" Version="4.3.1" />

--- a/src/NetCore-Selenium-3-141/Yasf.Common/Yasf.Common.csproj
+++ b/src/NetCore-Selenium-3-141/Yasf.Common/Yasf.Common.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ApplicationIcon />
     <StartupObject />
   </PropertyGroup>
@@ -151,30 +151,31 @@
 
   <ItemGroup>
     <PackageReference Include="Appium.WebDriver" Version="4.4.5" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
     <PackageReference Include="RestSharp" Version="108.0.3" />
     <PackageReference Include="Selenium.Firefox.WebDriver" Version="0.27.0" />
     <PackageReference Include="Selenium.Support" Version="3.141.0" />
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="115.0.5790.17000" />
-    <PackageReference Include="Selenium.WebDriver.IEDriver" Version="4.11.0" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="150.0.7871.4600" />
+    <PackageReference Include="Selenium.WebDriver.IEDriver" Version="4.14.0" />
     <PackageReference Include="Selenium.WebDriver.MicrosoftDriver" Version="17.17134.0" />
-    <PackageReference Include="Serilog" Version="3.0.1" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="7.0.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="7.0.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
-    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="7.0.0" />
+    <PackageReference Include="Serilog" Version="4.3.1" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.1" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
+    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="10.0.9" />
   </ItemGroup>
 
 </Project>

--- a/src/NetCore-Selenium/TheInternet.SystemTests.Raw/HotReloadScratchpad.cs
+++ b/src/NetCore-Selenium/TheInternet.SystemTests.Raw/HotReloadScratchpad.cs
@@ -55,7 +55,7 @@ namespace TheInternet.SystemTests.Raw
         public void HotReloadWorkflow()
         {
             // WebDriver.Navigate().GoToUrl("http://www.google.com");
-            // WebDriver.FindElement(By.Name("q")).SendKeys("howdi!" + Keys.Enter);
+            WebDriver.FindElement(By.Name("q")).SendKeys("howdi!" + Keys.Enter);
         }
     }
 }

--- a/src/NetCore-Selenium/TheInternet.SystemTests.Raw/Tests/FileUploadTests.cs
+++ b/src/NetCore-Selenium/TheInternet.SystemTests.Raw/Tests/FileUploadTests.cs
@@ -15,7 +15,7 @@ namespace TheInternet.SystemTests.Raw.Tests
         [Ignore("because this has issues in some execution contexts")]
         public void UploadFile()
         {
-            var path = System.IO.Path.Combine(TestContext.TestDeploymentDir, "Content", "SampleFileToUpload.txt");
+            var path = System.IO.Path.Combine(TestContext.DeploymentDirectory, "Content", "SampleFileToUpload.txt");
             var fileuploadElement = WebDriver.FindElements(By.XPath("//input[@id='file-upload']")).Single();
             fileuploadElement.SendKeys(path);
 

--- a/src/NetCore-Selenium/TheInternet.SystemTests.Raw/TheInternet.SystemTests.Raw.csproj
+++ b/src/NetCore-Selenium/TheInternet.SystemTests.Raw/TheInternet.SystemTests.Raw.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <PublishChromeDriver>true</PublishChromeDriver>
@@ -18,28 +18,28 @@
   </ItemGroup>  
 
   <ItemGroup>
-    <PackageReference Include="Appium.WebDriver" Version="5.0.0-beta01" />
-    <PackageReference Include="AutoFixture" Version="4.18.0" />
-    <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.18.0" />
-    <PackageReference Include="AutoFixture.Idioms" Version="4.18.0" />
+    <PackageReference Include="Appium.WebDriver" Version="8.3.0" />
+    <PackageReference Include="AutoFixture" Version="4.18.1" />
+    <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />
+    <PackageReference Include="AutoFixture.Idioms" Version="4.18.1" />
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
-    <PackageReference Include="FluentAssertions" Version="6.11.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+    <PackageReference Include="FluentAssertions" Version="7.2.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
     <PackageReference Include="Selenium.Firefox.WebDriver" Version="0.27.0" />
-    <PackageReference Include="Selenium.Support" Version="4.11.0" />
-    <PackageReference Include="Selenium.WebDriver" Version="4.11.0" />
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="115.0.5790.17000" />
-    <PackageReference Include="Selenium.WebDriver.IEDriver" Version="4.11.0" />
+    <PackageReference Include="Selenium.Support" Version="4.45.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.45.0" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="150.0.7871.4600" />
+    <PackageReference Include="Selenium.WebDriver.IEDriver" Version="4.14.0" />
   </ItemGroup>  
 
   <ItemGroup>

--- a/src/NetCore-Selenium/Yasf.Common.ExtentReports.SystemTests/Yasf.Common.ExtentReports.SystemTests.csproj
+++ b/src/NetCore-Selenium/Yasf.Common.ExtentReports.SystemTests/Yasf.Common.ExtentReports.SystemTests.csproj
@@ -1,35 +1,35 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <PublishChromeDriver>true</PublishChromeDriver>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Appium.WebDriver" Version="5.0.0-beta01" />
-    <PackageReference Include="AutoFixture" Version="4.18.0" />
-    <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.18.0" />
-    <PackageReference Include="AutoFixture.Idioms" Version="4.18.0" />
+    <PackageReference Include="Appium.WebDriver" Version="8.3.0" />
+    <PackageReference Include="AutoFixture" Version="4.18.1" />
+    <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />
+    <PackageReference Include="AutoFixture.Idioms" Version="4.18.1" />
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
-    <PackageReference Include="FluentAssertions" Version="6.11.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+    <PackageReference Include="FluentAssertions" Version="7.2.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
     <PackageReference Include="Selenium.Firefox.WebDriver" Version="0.27.0" />
-    <PackageReference Include="Selenium.Support" Version="4.11.0" />
-    <PackageReference Include="Selenium.WebDriver" Version="4.11.0" />
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="115.0.5790.17000" />
-    <PackageReference Include="Selenium.WebDriver.IEDriver" Version="4.11.0" />
+    <PackageReference Include="Selenium.Support" Version="4.45.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.45.0" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="150.0.7871.4600" />
+    <PackageReference Include="Selenium.WebDriver.IEDriver" Version="4.14.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NetCore-Selenium/Yasf.Common.ExtentReports/TestCaseReporter.cs
+++ b/src/NetCore-Selenium/Yasf.Common.ExtentReports/TestCaseReporter.cs
@@ -42,7 +42,8 @@ namespace Yasf.Common.ExtentReports
 
         public void Debug(string message)
         {
-            Log(Status.Debug, $"{message}");
+            // Status.Debug appears to have been removed
+            Log(Status.Info, $"{message}");
         }
 
         public void Information(string message)

--- a/src/NetCore-Selenium/Yasf.Common.ExtentReports/TestRunReporter.cs
+++ b/src/NetCore-Selenium/Yasf.Common.ExtentReports/TestRunReporter.cs
@@ -9,7 +9,7 @@ namespace Yasf.Common.ExtentReports
         public string TestRunIdentity { get; }
         public string ReportOutputFolder => System.IO.Path.Combine(RootOutputFolder, TestRunIdentity);
         internal AventStack.ExtentReports.ExtentReports ExtentReporter { get; private set; }
-        private AventStack.ExtentReports.Reporter.ExtentHtmlReporter _htmlReporter;
+        private AventStack.ExtentReports.Reporter.ExtentSparkReporter _htmlReporter;
 
         public TestRunReporter(string rootOutputFolder, string testRunIdentity)
         {
@@ -22,7 +22,7 @@ namespace Yasf.Common.ExtentReports
             ExtentReporter = new AventStack.ExtentReports.ExtentReports();
 
             // NOTE: For some reason, I need to specify the path here or it goes 'one level up'. Am I missing something?
-            _htmlReporter = new AventStack.ExtentReports.Reporter.ExtentHtmlReporter(System.IO.Path.Combine(ReportOutputFolder, "index.html"));
+            _htmlReporter = new AventStack.ExtentReports.Reporter.ExtentSparkReporter(System.IO.Path.Combine(ReportOutputFolder, "index.html"));
 
             ExtentReporter.AttachReporter(_htmlReporter);
         }

--- a/src/NetCore-Selenium/Yasf.Common.ExtentReports/Yasf.Common.ExtentReports.csproj
+++ b/src/NetCore-Selenium/Yasf.Common.ExtentReports/Yasf.Common.ExtentReports.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ExtentReports" Version="4.1.0" />
+    <PackageReference Include="ExtentReports" Version="5.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NetCore-Selenium/Yasf.Common.SystemTests/Yasf.Common.SystemTests.csproj
+++ b/src/NetCore-Selenium/Yasf.Common.SystemTests/Yasf.Common.SystemTests.csproj
@@ -1,35 +1,35 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <PublishChromeDriver>true</PublishChromeDriver>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Appium.WebDriver" Version="5.0.0-beta01" />
-    <PackageReference Include="AutoFixture" Version="4.18.0" />
-    <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.18.0" />
-    <PackageReference Include="AutoFixture.Idioms" Version="4.18.0" />
+    <PackageReference Include="Appium.WebDriver" Version="8.3.0" />
+    <PackageReference Include="AutoFixture" Version="4.18.1" />
+    <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />
+    <PackageReference Include="AutoFixture.Idioms" Version="4.18.1" />
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
-    <PackageReference Include="FluentAssertions" Version="6.11.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+    <PackageReference Include="FluentAssertions" Version="7.2.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
     <PackageReference Include="Selenium.Firefox.WebDriver" Version="0.27.0" />
-    <PackageReference Include="Selenium.Support" Version="4.11.0" />
-    <PackageReference Include="Selenium.WebDriver" Version="4.11.0" />
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="115.0.5790.17000" />
-    <PackageReference Include="Selenium.WebDriver.IEDriver" Version="4.11.0" />
+    <PackageReference Include="Selenium.Support" Version="4.45.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.45.0" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="150.0.7871.4600" />
+    <PackageReference Include="Selenium.WebDriver.IEDriver" Version="4.14.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NetCore-Selenium/Yasf.Common.UnitTests/Reporting/ReportingContextRegistrationManagerTests.cs
+++ b/src/NetCore-Selenium/Yasf.Common.UnitTests/Reporting/ReportingContextRegistrationManagerTests.cs
@@ -157,10 +157,9 @@ namespace Yasf.Common.UnitTests.Reporting
             }
 
             [TestMethod]
-            [ExpectedException(typeof(InvalidOperationException))]
             public void DefaultReportingCannotBeConfiguredAgain()
             {
-                manager.PopulateDefaultReportingContexts();
+                Assert.ThrowsExactly<InvalidOperationException>(() => manager.PopulateDefaultReportingContexts());
             }
         }
 
@@ -184,10 +183,9 @@ namespace Yasf.Common.UnitTests.Reporting
             }
 
             [TestMethod]
-            [ExpectedException(typeof(InvalidOperationException))]
             public void DefaultReportingCannotBeConfigured()
             {
-                manager.PopulateDefaultReportingContexts();
+                Assert.ThrowsExactly<InvalidOperationException>(() => manager.PopulateDefaultReportingContexts());
             }
         }
     }

--- a/src/NetCore-Selenium/Yasf.Common.UnitTests/Yasf.Common.UnitTests.csproj
+++ b/src/NetCore-Selenium/Yasf.Common.UnitTests/Yasf.Common.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -33,15 +33,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.18.0" />
-    <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.18.0" />
-    <PackageReference Include="AutoFixture.Idioms" Version="4.18.0" />
-    <PackageReference Include="FluentAssertions" Version="6.11.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="AutoFixture" Version="4.18.1" />
+    <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />
+    <PackageReference Include="AutoFixture.Idioms" Version="4.18.1" />
+    <PackageReference Include="FluentAssertions" Version="7.2.2" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/NetCore-Selenium/Yasf.Common/Drivers/DriverDecorator.cs
+++ b/src/NetCore-Selenium/Yasf.Common/Drivers/DriverDecorator.cs
@@ -2,6 +2,8 @@
 using OpenQA.Selenium.Remote;
 using System;
 using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Yasf.Common.SessionManagement;
 
 namespace Yasf.Common.Drivers
@@ -138,11 +140,13 @@ namespace Yasf.Common.Drivers
                     var newSession = executor(driverCommandToExecute, parameters);
                     if (newSession.Status != WebDriverResult.Success) return newSession;
 
+                    // NOTE: The explicit serialization call here is to coerce Value, SessionId and Status to value, sessionId and status so that AttachableSeleniumSessionStorage
+                    //       can still blindly call Response.FromJson to rebuild a valid attachable browser context. 
                     var attachableSeleniumSession = new AttachableSeleniumSession()
                     {
                         BrowserName = _browserName,
                         Response = newSession,
-                        OfficialResponse = newSession.ToJson(),
+                        OfficialResponse = JsonSerializer.Serialize(newSession, new JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }),
                         RemoteServerUri = GetRemoteServerUri(),
                         CommandRepositoryTypeName = GetCommandInfoRepository().GetType().FullName
                     };

--- a/src/NetCore-Selenium/Yasf.Common/ElementOperations/DecoratedWebDriver.cs
+++ b/src/NetCore-Selenium/Yasf.Common/ElementOperations/DecoratedWebDriver.cs
@@ -6,6 +6,8 @@ using System.Collections.ObjectModel;
 using Yasf.Common.ElementOperations.Contracts;
 using Yasf.Common.ExecutionContext.Runtime.ControlSettings;
 using Yasf.Common.Reporting.Contracts;
+using System.Threading.Tasks;
+using System;
 
 namespace Yasf.Common.ElementOperations
 {
@@ -53,6 +55,14 @@ namespace Yasf.Common.ElementOperations
         public void Dispose()
         {
             _original.Dispose();
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            // TODO: Revisit this
+            this.Dispose();
+
+            return ValueTask.CompletedTask;
         }
 
         public IWebElement FindElement(By by)

--- a/src/NetCore-Selenium/Yasf.Common/ElementOperations/WebDriverAssertions.cs
+++ b/src/NetCore-Selenium/Yasf.Common/ElementOperations/WebDriverAssertions.cs
@@ -235,7 +235,8 @@ namespace Yasf.Common.ElementOperations
 
             if (condition.State.HasFlag(ElementState.IsDisplayed))
             {
-                if (!webElement.Displayed) throw new NoSuchElementException($"The Element is not visible", new ElementNotVisibleException($"The Element is not visible: {webElement}"));
+                // NOTE: ElementNotVisibleException is not defined in Selenium 4+. ElementNotInteractableException is now the supported method: https://github.com/SeleniumHQ/selenium/issues/10538
+                if (!webElement.Displayed) throw new NoSuchElementException($"The Element is not visible", new ElementNotInteractableException($"The Element is not visible: {webElement}"));
             }
 
             if (condition.State.HasFlag(ElementState.IsEnabled))

--- a/src/NetCore-Selenium/Yasf.Common/Infrastructure/MsTestInitialization.cs
+++ b/src/NetCore-Selenium/Yasf.Common/Infrastructure/MsTestInitialization.cs
@@ -46,7 +46,7 @@ namespace Yasf.Common.Infrastructure
             var testExecutionContextName = $"{Environment.GetEnvironmentVariable($"{prefix}TEST_EXECUTION_CONTEXT") ?? defaultTestExecutionContext}";
             Log.Logger.Information($"Candidate Test Exection Context to use: {testExecutionContextName}");
 
-            if (testContext.Properties.Contains(TEST_EXECUTION_CONTEXT_KEY_NAME))
+            if (testContext.Properties.ContainsKey(TEST_EXECUTION_CONTEXT_KEY_NAME))
             {
                 Log.Logger.Information($"The .runsettings contains a property called {TEST_EXECUTION_CONTEXT_KEY_NAME}. We will retrieve that. ");
                 testExecutionContextName = Convert.ToString(testContext.Properties[TEST_EXECUTION_CONTEXT_KEY_NAME]);

--- a/src/NetCore-Selenium/Yasf.Common/SessionManagement/AttachableSeleniumSessionStorage.cs
+++ b/src/NetCore-Selenium/Yasf.Common/SessionManagement/AttachableSeleniumSessionStorage.cs
@@ -42,6 +42,9 @@ namespace Yasf.Common.SessionManagement
                 var persistedSession = JsonConvert.DeserializeObject<AttachableSeleniumSession>(persistedSessionContent);
                 var persistedSessionContentAsJObject = JsonConvert.DeserializeObject<JObject>(persistedSessionContent);
 
+                // TODO: Refactor this to support attaching
+                /*
+
                 var officialResponse = Response.FromJson(persistedSession.OfficialResponse);
                 officialResponse.SessionId = persistedSession.Response.SessionId;
 
@@ -58,7 +61,8 @@ namespace Yasf.Common.SessionManagement
                 var officialResponseValueDictionary = officialResponse.Value as Dictionary<string, object>;
                 newSession.Response.Value = officialResponseValueDictionary["Value"];
 
-                return newSession;
+                return newSession;*/
+                return null;
             }
             catch
             {

--- a/src/NetCore-Selenium/Yasf.Common/SessionManagement/AttachableSeleniumSessionStorage.cs
+++ b/src/NetCore-Selenium/Yasf.Common/SessionManagement/AttachableSeleniumSessionStorage.cs
@@ -42,11 +42,7 @@ namespace Yasf.Common.SessionManagement
                 var persistedSession = JsonConvert.DeserializeObject<AttachableSeleniumSession>(persistedSessionContent);
                 var persistedSessionContentAsJObject = JsonConvert.DeserializeObject<JObject>(persistedSessionContent);
 
-                // TODO: Refactor this to support attaching
-                /*
-
                 var officialResponse = Response.FromJson(persistedSession.OfficialResponse);
-                officialResponse.SessionId = persistedSession.Response.SessionId;
 
                 var newSession = new AttachableSeleniumSession()
                 {
@@ -58,11 +54,7 @@ namespace Yasf.Common.SessionManagement
                     CommandRepositoryTypeName = persistedSession.CommandRepositoryTypeName
                 };
 
-                var officialResponseValueDictionary = officialResponse.Value as Dictionary<string, object>;
-                newSession.Response.Value = officialResponseValueDictionary["Value"];
-
-                return newSession;*/
-                return null;
+                return newSession;
             }
             catch
             {

--- a/src/NetCore-Selenium/Yasf.Common/Yasf.Common.csproj
+++ b/src/NetCore-Selenium/Yasf.Common/Yasf.Common.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ApplicationIcon />
     <StartupObject />
   </PropertyGroup>
@@ -150,31 +150,32 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Appium.WebDriver" Version="5.0.0-beta01" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+    <PackageReference Include="Appium.WebDriver" Version="8.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="RestSharp" Version="108.0.3" />
     <PackageReference Include="Selenium.Firefox.WebDriver" Version="0.27.0" />
-    <PackageReference Include="Selenium.Support" Version="4.11.0" />
-    <PackageReference Include="Selenium.WebDriver" Version="4.11.0" />
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="115.0.5790.17000" />
-    <PackageReference Include="Selenium.WebDriver.IEDriver" Version="4.11.0" />
+    <PackageReference Include="Selenium.Support" Version="4.45.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.45.0" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="150.0.7871.4600" />
+    <PackageReference Include="Selenium.WebDriver.IEDriver" Version="4.14.0" />
     <PackageReference Include="Selenium.WebDriver.MicrosoftDriver" Version="17.17134.0" />
-    <PackageReference Include="Serilog" Version="3.0.1" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="7.0.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="7.0.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
-    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="7.0.0" />
+    <PackageReference Include="Serilog" Version="4.3.1" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.1" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
+    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="10.0.9" />
   </ItemGroup>
 
 </Project>

--- a/src/NetCore-Selenium/testEnvironments.json
+++ b/src/NetCore-Selenium/testEnvironments.json
@@ -1,0 +1,17 @@
+﻿{
+  "version": "1",
+  "environments": [
+    // See https://aka.ms/remotetesting for more details
+    // about how to configure remote environments.
+    //{
+    //  "name": "WSL Ubuntu",
+    //  "type": "wsl",
+    //  "wslDistribution": "Ubuntu"
+    //},
+    //{
+    //  "name": "Docker dotnet/sdk",
+    //  "type": "docker",
+    //  "dockerImage": "mcr.microsoft.com/dotnet/sdk"
+    //}
+  ]
+}

--- a/src/global.json
+++ b/src/global.json
@@ -1,0 +1,6 @@
+{
+    "sdk": {
+        "version": "8.0.422",
+        "rollForward": "disable"
+    }
+}

--- a/src/global.json
+++ b/src/global.json
@@ -1,6 +1,0 @@
-{
-    "sdk": {
-        "version": "8.0.422",
-        "rollForward": "disable"
-    }
-}


### PR DESCRIPTION
- Target .NET 8
- Update all dependencies to latest to support Selenium 3.141
- FluentValidation updated to latest non-commercial version. 
